### PR TITLE
allow to log not only string values

### DIFF
--- a/src/cjaeger.h
+++ b/src/cjaeger.h
@@ -42,6 +42,10 @@ void cjaeger_span_finish(void *span);
 void cjaeger_span_log(void *span, const char *key, const char *value);
 void cjaeger_span_log2(void *span, const char *key, const char *value, size_t value_len);
 void cjaeger_span_log3(void *span, const char *key, size_t key_len, const char *value, size_t value_len);
+void cjaeger_span_logd(void *span, const char *key, size_t key_len, int64_t value);
+void cjaeger_span_logu(void *span, const char *key, size_t key_len, uint64_t value);
+void cjaeger_span_logfp(void *span, const char *key, size_t key_len, double value);
+void cjaeger_span_logb(void *span, const char *key, size_t key_len, bool value);
 
 # ifdef  __cplusplus
 }


### PR DESCRIPTION
Introduce functions to log non-string primitive types:
- cjaeger_span_logd(), for int64_t
- cjaeger_span_logu(), for uint64_t
- cjaeger_span_logfp(), for double
- cjaeger_span_logb(), for bool

cjaeger_span_logd() and cjaeger_span_logu() still convert large integers
to strings as they now cannot be showed correctly by jaeger UI.